### PR TITLE
doc: updates README witha  note to load_extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ See full configuration options in `lua/cmdline/config.lua` file.
 
 ## Trigger
 
+⚠️ Make sure to load the `cmdline` extension, so that the `Telescope cmdline` command is available.
+
+```lua
+require("telescope").load_extension("cmdline")
+```
+
 Cmdline can be executed using `:Telescope cmdline<CR>`, but it doesn't
 include any mapping by default.
 


### PR DESCRIPTION
As [mentioned](https://github.com/jonarrien/telescope-cmdline.nvim/issues/4#issuecomment-1646678136) in #4 by @jonarrien, loading the extension solves a problem you have just after installing.

---

I just gave this a go as part of improving my nvim setup - and I like it! Thank you for building the plugin :heart: 