### PR TITLE
Fuzzy search

### DIFF
--- a/lua/cmdline/state.lua
+++ b/lua/cmdline/state.lua
@@ -35,7 +35,7 @@ end
 -- Public
 
 M.autocomplete    = function(text)
-	if text:sub(-1) == " " or #text <= #previous_search then
+	if #previous_search == 0 or text:sub(-1) == " " or #text <= #previous_search then
 		local split = vim.split(text, " ")
 		table.remove(split)
 		local input_start = table.concat(split, " ")

--- a/lua/cmdline/state.lua
+++ b/lua/cmdline/state.lua
@@ -10,6 +10,7 @@ cache.system     = {}
 
 local M          = {}
 local fn         = {}
+local previous_search = ""
 
 fn.add_command   = function(index, cmd)
   table.insert(cache.commands, { id = 1000 + index, cmd = cmd, type = 'command' })
@@ -34,18 +35,21 @@ end
 -- Public
 
 M.autocomplete    = function(text)
-  local split = vim.split(text, ' ')
-  table.remove(split)
-  local input_start = table.concat(split, ' ')
-  local completions = assert(vim.fn.getcompletion(text, 'cmdline'), 'No completions found')
-  cache.commands = {}
+	if text:sub(-1) == " " or #text <= #previous_search then
+		local split = vim.split(text, " ")
+		table.remove(split)
+		local input_start = table.concat(split, " ")
+		local completions = assert(vim.fn.getcompletion(text, "cmdline"), "No completions found")
+		cache.commands = {}
 
-  for i = #completions, 1, -1 do
-    local suggestion = table.concat({ input_start, completions[i] }, ' ')
-    fn.add_command(i, vim.trim(suggestion))
-  end
+		for i = #completions, 1, -1 do
+			local suggestion = table.concat({ input_start, completions[i] }, " ")
+			fn.add_command(i, vim.trim(suggestion))
+		end
+		previous_search = text
+	end
 
-  return cache.commands
+	return cache.commands
 end
 
 M.system_command  = function(text)


### PR DESCRIPTION
Fixes https://github.com/jonarrien/telescope-cmdline.nvim/issues/12

Allows to fuzzy search sub-commands of the input string before the last space.
For example:
Let's say you want to find `Telescope cmdline visual`. Since on empty only the history is provided, you need to start typing with the first letter the same as command. But all the characters will be used for fuzzy search. Assuming you don't have any "Telescope" entries in your cmd line history you could simply type `tlsp<TAB> cne<TAB> vi` and `<C-CR>` to confirm.

This is done by not updating the whole list with autocomplete results every time user types something in, but rather only when:
1. You type into the search box for the first time
2. The last character of the input is space
3. Current input string is shorter than the previous one (i.e. user pressed backspace)