### PR TITLE
Bugfix: Search not being fuzzy for history entries after space

### DIFF
--- a/lua/cmdline/state.lua
+++ b/lua/cmdline/state.lua
@@ -88,12 +88,7 @@ M.command_history     = function(text)
 
   for i = #history_list, 3, -1 do
     local item = history_list[i]
-
-    if text == nil or text == "" then
-      fn.add_history(fn.parse_history(item))
-    elseif string.find(item, text) then
-      fn.add_history(fn.parse_history(item))
-    end
+    fn.add_history(fn.parse_history(item))
   end
   return cache.history
 end


### PR DESCRIPTION
Fixes https://github.com/jonarrien/telescope-cmdline.nvim/issues/14

Because the list of history and autocomplete entries is refreshed every time after a space is entered, filtering list manually leads to an issue where if user types a space the history entries are not fuzzy-searched anymore. Leaving the filtering to Telescope solves the issue.