### PR TITLE
refactor: revamp fuzzy search and fix command completion

### DIFF
--- a/lua/cmdline/actions.lua
+++ b/lua/cmdline/actions.lua
@@ -78,7 +78,7 @@ A.complete_input = function(prompt_bufnr)
   local command = action_state.get_selected_entry()
   if not command then return end
   local picker = action_state.get_current_picker(prompt_bufnr)
-  picker:set_prompt(command.cmd)
+  picker:set_prompt(vim.trim(command.cmd))
 end
 
 A.edit = function(prompt_bufnr)

--- a/lua/cmdline/config.lua
+++ b/lua/cmdline/config.lua
@@ -4,7 +4,7 @@ local defaults = {
   },
   icons       = {
     history = " ",
-    command = " ", -- 󰣿 󰏤 
+    command = " ", -- 󰣿 󰴲 󰏤 
     number  = "󰴍 ",
     system  = "",
     unknown = "",
@@ -26,7 +26,7 @@ local defaults = {
   overseer    = {
     enabled = true,
   },
-  output_pane      = {
+  output_pane = {
     enabled = false
   }
 }

--- a/lua/cmdline/init.lua
+++ b/lua/cmdline/init.lua
@@ -27,8 +27,8 @@ local C = {}
 
 -- Complete based on user input
 -- 1. Numbers  => Go to line
--- 2. Detect terminal commands (starting with !)
--- 3. No input => Show command history
+-- 2. No input => Show command history to pick latest commands easily
+-- 3. System   => Detect commands starting with !
 -- 4. Load completion
 -- @param text string: user input
 C.autocomplete = function(text)
@@ -36,7 +36,7 @@ C.autocomplete = function(text)
     return { { type = 'number', index = 1, cmd = text, desc = 'Go to line ' .. text } }
   end
 
-  local history = state.command_history(text)
+  local history = state.command_history()
   if string.len(text) == 0 then return history end
 
   if string.sub(text, 1, 1) == '!' then
@@ -44,8 +44,8 @@ C.autocomplete = function(text)
     return utils.merge_results(system_commands, history)
   end
 
-  local completions = state.autocomplete(text)
-  return utils.merge_results(completions, history)
+  local commands = state.autocomplete(text)
+  return utils.merge_results(commands, history)
 end
 
 return C

--- a/lua/cmdline/sorter.lua
+++ b/lua/cmdline/sorter.lua
@@ -1,0 +1,47 @@
+local sorters = require('telescope.sorters')
+
+return function(opts)
+  opts = opts or {}
+  local fzy = opts.fzy_mod or require "telescope.algos.fzy"
+  local OFFSET = -fzy.get_score_floor()
+
+  return sorters.Sorter:new {
+    discard = true,
+
+    scoring_function = function(_, prompt, line, entry)
+      -- Check for actual matches before running the scoring alogrithm.
+      if not fzy.has_match(prompt, line) then
+        return -1
+      end
+
+      local fzy_score = fzy.score(prompt, line)
+
+      -- The fzy score is -inf for empty queries and overlong strings.  Since
+      -- this function converts all scores into the range (0, 1), we can
+      -- convert these to 1 as a suitable "worst score" value.
+      if fzy_score == fzy.get_score_min() then
+        return 1
+      end
+
+      -- Prioritise commands over history
+      if entry.type == "command" then
+        return 1 / ((fzy_score + OFFSET) * 1.15)
+      end
+
+      -- Poor non-empty matches can also have negative values. Offset the score
+      -- so that all values are positive, then invert to match the
+      -- telescope.Sorter "smaller is better" convention. Note that for exact
+      -- matches, fzy returns +inf, which when inverted becomes 0.
+      return 1 / (fzy_score + OFFSET)
+    end,
+
+    -- The fzy.positions function, which returns an array of string indices, is
+    -- compatible with telescope's conventions. It's moderately wasteful to
+    -- call call fzy.score(x,y) followed by fzy.positions(x,y): both call the
+    -- fzy.compute function, which does all the work. But, this doesn't affect
+    -- perceived performance.
+    highlighter = function(_, prompt, display)
+      return fzy.positions(prompt, display)
+    end,
+  }
+end

--- a/lua/cmdline/state.lua
+++ b/lua/cmdline/state.lua
@@ -1,60 +1,138 @@
+-- Characters that trigger new autocompletion
+local trigger_characters = { " ", "/" }
+
+-- Arrays to store results
+local cache              = {}
+cache.all_commands       = {}
+cache.commands           = {}
+cache.history            = {}
+cache.system             = {}
+
+-- Search
+local search             = {}
+search.previous          = ""
+search.current_keyword   = nil
+
+local start_index        = {}
+start_index.commands     = 0
+start_index.history      = 5000
+start_index.system       = 10000
+
 local function compare(a, b)
   return a.cmd < b.cmd
 end
 
--- Arrays to store results
-local cache           = {}
-cache.commands        = {}
-cache.history         = {}
-cache.system          = {}
+local fn            = {}
 
--- Search
-local previous_search = ""
-
-local fn              = {}
-
-fn.add_command        = function(index, cmd)
-  table.insert(cache.commands, { id = 1000 + index, cmd = cmd, type = 'command' })
+fn.add_command      = function(index, cmd)
+  table.insert(cache.commands, { id = start_index.commands + index, cmd = cmd, type = 'command' })
 end
 
-fn.add_history        = function(index, cmd)
-  table.insert(cache.history, { id = index, cmd = cmd, type = 'history' })
+fn.add_history      = function(index, cmd)
+  table.insert(cache.history, { id = start_index.history + index, cmd = cmd, type = 'history' })
 end
 
-fn.add_system         = function(index, cmd)
-  table.insert(cache.system, { id = index, cmd = "!" .. cmd, type = 'system' })
+fn.add_system       = function(index, cmd)
+  table.insert(cache.system, { id = start_index.system + index, cmd = "!" .. cmd, type = 'system' })
 end
 
-fn.parse_history      = function(entry)
+fn.parse_history    = function(entry)
   local d1, d2 = string.find(entry, '%d+')
   local digit = string.sub(entry, d1, d2)
   local _, finish = string.find(entry, '%d+ +')
   return digit, string.sub(entry, finish + 1)
 end
 
+fn.parse_command    = function(keyword, completions)
+  local items = {}
+  for i = #completions, 1, -1 do
+    local suggestion = table.concat({ keyword, completions[i] }, " ")
+    fn.add_command(i, vim.trim(suggestion))
+  end
+  return items
+end
+
+-- Preload existing commands on initialisation
+fn.preload_commands = function()
+  local list = vim.fn.getcompletion("", "cmdline")
+  local completions = assert(list, "No completions found")
+  cache.all_commands = {}
+
+  for i = #completions, 1, -1 do
+    table.insert(cache.all_commands, {
+      id = start_index.commands + i,
+      cmd = vim.trim(completions[i]),
+      type = 'command'
+    })
+  end
+end
+
+
+fn.is_trigger_char = function(value)
+  for i = 1, #trigger_characters do
+    if (trigger_characters[i] == value) then return true end
+  end
+  return false
+end
+
+-- Create a new table, removing duplicates values
+-- @param obj {table}
+-- @return {table}
+fn.uniq            = function(obj)
+  local output = {}
+  local seen = {}
+
+  for i = 1, #obj do
+    local value = obj[i]
+    if not seen[value] then
+      seen[value] = true
+      table.insert(output, value)
+    end
+  end
+
+  return output
+end
+
+
 -- Public
 
-local M               = {}
+local M           = {}
 
-M.autocomplete        = function(text)
-  if #previous_search == 0 or text:sub(-1) == " " or #text <= #previous_search then
-    local split = vim.split(text, " ")
-    table.remove(split)
-    local input_start = table.concat(split, " ")
-    local completions = assert(vim.fn.getcompletion(text, "cmdline"), "No completions found")
+-- Autocompletes user input
+--
+-- 1. When no spaces are provided, provide all existing commands
+--    for fuzzy search.
+-- 2. When last character is triggerable, use nvim's completion for the
+--    next results.
+--
+-- @param text string: user input
+M.autocomplete    = function(text)
+  local splits = vim.split(text, " ")
+
+  if not cache.all_commands then fn.preload_commands() end
+
+  if #splits == 0 then return cache.all_commands end
+
+  if #search.previous == 0 or fn.is_trigger_char(text:sub(-1)) or #text < #search.previous then
+    table.remove(splits)
+    search.current_keyword = vim.trim(table.concat(splits, " "))
+
+    local list = vim.fn.getcompletion(text, "cmdline")
+    local completions = assert(list, "No completions found")
     cache.commands = {}
 
     for i = #completions, 1, -1 do
-      local suggestion = table.concat({ input_start, completions[i] }, " ")
+      local completion = vim.trim(completions[i])
+      local suggestion = table.concat({ search.current_keyword, completions[i] }, " ")
       fn.add_command(i, vim.trim(suggestion))
     end
-    previous_search = text
+    search.previous = text
   end
 
   return cache.commands
 end
 
-M.system_command      = function(text)
+M.system_command  = function(text)
   local split = vim.split(text, ' ')
   local parts = #split
   local input_start = ''
@@ -80,25 +158,19 @@ M.system_command      = function(text)
   return cache.system
 end
 
--- Loads full history when no text is provided and matches when text is provided
-M.command_history     = function(text)
+-- Loads full command history
+M.command_history = function()
   local history_string = assert(vim.fn.execute('history cmd'), 'History is empty')
   local history_list = vim.split(history_string, '\n')
   cache.history = {}
 
   for i = #history_list, 3, -1 do
-    local item = history_list[i]
-
-    if text == nil or text == "" then
-      fn.add_history(fn.parse_history(item))
-    elseif string.find(item, text) then
-      fn.add_history(fn.parse_history(item))
-    end
+    fn.add_history(fn.parse_history(history_list[i]))
   end
-  return cache.history
+  return fn.uniq(cache.history)
 end
 
-M.sort                = function(table)
+M.sort            = function(table)
   table.sort(table, compare)
 end
 

--- a/lua/telescope/_extensions/cmdline.lua
+++ b/lua/telescope/_extensions/cmdline.lua
@@ -8,8 +8,9 @@ local cmdline = require('cmdline')
 local action = require('cmdline.actions')
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
-local sorter = require("telescope.sorters")
 local entry_display = require("telescope.pickers.entry_display")
+
+local sorter = require('cmdline.sorter')
 
 local get_config = function()
   local config = require('cmdline.config')
@@ -56,7 +57,7 @@ local make_picker = function(opts)
     prompt_title = "Cmdline",
     prompt_prefix = " : ",
     finder = make_finder(config),
-    sorter = sorter.get_fzy_sorter(opts),
+    sorter = sorter(opts),
     attach_mappings = function(_, map)
       map("i", config.mappings.complete, action.complete_input)     -- <Tab>
       map("i", config.mappings.run_input, action.run_input)         -- <CR>


### PR DESCRIPTION
After adding fuzzy search functionality, some command completions stopped working (`:e`, `:vs`, `:tabe`, etc.). This PR focuses on: 
* recovering command completion
* revamp fuzzy search  
* prioritise command entries a bit over history ones 