### PR TITLE
refactor: use enter to pick completion element

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,29 @@ You can customise cmdline settings in telescope configuration.
 
 ```lua
 require("telescope").setup({
-  ...
+  -- ...
   extensions = {
     cmdline = {
+      -- Adjust telescope picker size and layout
       picker = {
         layout_config = {
           width  = 120,
           height = 25,
         }
       },
+      -- Adjust your mappings 
       mappings    = {
         complete      = '<Tab>',
         run_selection = '<C-CR>',
         run_input     = '<CR>',
       },
+      -- Triggers any shell command using overseer.nvim (`:!`)
+      overseer    = {
+        enabled = true,
+      },
     },
   }
-  ...
+  -- ...
 })
 ```
 
@@ -101,15 +107,13 @@ require("telescope").setup({
 
 ## Mappings
 
-- `<CR>`  Run user input if entered, otherwise run first selection
+- `<CR>`  Runs selected command from completion, otherwise runs user input
 - `<TAB>` complete current selection into input (useful for :e, :split, :vsplit, :tabnew)
-- `<C-CR>`Run selection directly
 - `<C-e>` edit current selection in prompt
 
 Cmdline can be executed using `:Telescope cmdline<CR>`, but it doesn't
-include any mapping by default. Normally I use ':' to trigger it, but
-it's true there are some caveats or edge cases. 
-
+include any mapping by default. Normally I suggest using ':' to
+trigger it, but it's true there are some caveats or edge cases.
 Please, configure the mapping which suits best for you:
 
 ```lua

--- a/lua/cmdline/actions.lua
+++ b/lua/cmdline/actions.lua
@@ -29,14 +29,23 @@ local run = function(cmd)
   end
 
   -- System command
-  if config.values.overseer.enabled and string.sub(cmd, 1, 1) == '!' then
-    vim.api.nvim_exec2('OverseerRunCmd ' .. cmd:sub(2), {})
-    vim.api.nvim_exec2('OverseerOpen', {})
+  if string.sub(cmd, 1, 1) == '!' then
+    if config.values.overseer.enabled then
+      vim.api.nvim_exec2('OverseerRunCmd ' .. cmd:sub(2), {})
+      vim.api.nvim_exec2('OverseerOpen', {})
+    else
+      vim.cmd.split("term://" .. cmd:sub(2))
+    end
     return
   end
 
   -- Run command and get output
-  local data = vim.api.nvim_exec2(cmd, { output = true })
+  local executed, data = pcall(vim.api.nvim_exec2, cmd, { output = true })
+  if not executed then
+    vim.notify('Error executing command: ' .. cmd, vim.log.levels.ERROR, {})
+    return
+  end
+  -- local data = vim.api.nvim_exec2(cmd, { output = true })
   local output = data.output
 
   -- Skip output on silent or custom commands

--- a/lua/cmdline/config.lua
+++ b/lua/cmdline/config.lua
@@ -20,11 +20,11 @@ local defaults = {
   },
   mappings    = {
     complete      = '<Tab>',
-    run_selection = '<C-CR>',
-    run_input     = '<CR>',
+    run_selection = '<CR>',
+    run_input     = '<C-CR>',
   },
   overseer    = {
-    enabled = true,
+    enabled = false,
   },
   output_pane = {
     enabled = false,

--- a/lua/telescope/_extensions/cmdline.lua
+++ b/lua/telescope/_extensions/cmdline.lua
@@ -51,10 +51,14 @@ local make_picker = function(opts)
     finder = make_finder(config),
     sorter = sorter(opts),
     attach_mappings = function(_, map)
-      map("i", config.mappings.complete, action.complete_input)     -- <Tab>
-      map("i", config.mappings.run_input, action.run_input)         -- <CR>
-      map("i", config.mappings.run_selection, action.run_selection) -- <C-CR>
+      -- Autocomplete using <Tab>
+      map("i", config.mappings.complete, action.complete_input)
+      -- Run selection with <CR>
+      map("i", config.mappings.run_selection, action.run_selection)
+      -- Run command from input field with <C-CR> (special cases) ??
+      map("i", config.mappings.run_input, action.run_input)
       map("i", "<C-e>", action.edit)
+
       require("telescope.actions").close:enhance {
         post = function()
           cmdline.preview.clean(vim.api.nvim_win_get_buf(0))


### PR DESCRIPTION
This commit makes the plugin behave like any other telescope plugin, where `<CR>` picks the selected element. This plugin was prioritizing user's input instead to avoid some special cases. 

The issue, it was requiring pressing `<TAB>` key to move the selected element from the list to user's prompt. Otherwise, fuzzy finding text (incomplete in most cases) was executed as command (triggering an error).

NOTE: Disables `overseer.nvim` integration by default and executes shell commands in a split terminal.