### PR TITLE
Get full error message for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ vim.api.nvim_set_keymap('n', ':', ':Telescope cmdline<CR>', { noremap = true, de
 vim.api.nvim_set_keymap('n', '<leader><leader>', ':Telescope cmdline<CR>', { noremap = true, desc = "Cmdline" })
 ```
 
+## Caveats
+
+- Only the first error message of several may be displayed, because the Neovim Lua API
+  does not return multiple errors. For example, running `q` or `quit` from the standard
+  command line when there are unsaved changes returns multiple errors, the second and
+  subsequent errors tell which buffers have unsaved changes, but the first error, the
+  only one available to `telescope-cmdline.nvim`, just says "No write since last change".
+
 ## Notes
 
 - [x] Support normal mode

--- a/lua/cmdline/actions.lua
+++ b/lua/cmdline/actions.lua
@@ -42,7 +42,10 @@ local run = function(cmd)
   -- Run command and get output
   local executed, data = pcall(vim.api.nvim_exec2, cmd, { output = true })
   if not executed then
-    vim.notify('Error executing command: ' .. cmd, vim.log.levels.ERROR, {})
+    -- Parse the trailing fragment of Vimscript-Lua "bridged" error messages
+    -- (i.e. `Vim(COMMAND_NAME):E999: Error message`)
+    local msg = data:match('Vim%([^)]*%):(.*)$')
+    vim.notify('Error executing command: ' .. cmd .. '\n' .. msg, vim.log.levels.ERROR, {})
     return
   end
   -- local data = vim.api.nvim_exec2(cmd, { output = true })


### PR DESCRIPTION
When a command line command fails, get the complete error message returned by `pcall(nvim_exec2, ...)`

Also add a caveat to the README about error messages.