### PR TITLE
feat: added a mappable close action

### DIFF
--- a/lua/cmdline/actions.lua
+++ b/lua/cmdline/actions.lua
@@ -110,4 +110,8 @@ A.run_selection = function(prompt_bufnr)
   run(command.cmd)
 end
 
+A.close = function(prompt_bufnr) 
+    actions.close(prompt_bufnr)
+end
+
 return A

--- a/lua/cmdline/config.lua
+++ b/lua/cmdline/config.lua
@@ -22,6 +22,7 @@ local defaults = {
     complete      = '<Tab>',
     run_selection = '<CR>',
     run_input     = '<C-CR>',
+    close         = '<C-c',
   },
   overseer    = {
     enabled = false,

--- a/lua/telescope/_extensions/cmdline.lua
+++ b/lua/telescope/_extensions/cmdline.lua
@@ -59,6 +59,8 @@ local make_picker = function(opts)
       -- Run command from input field with <C-CR> (special cases) ??
       map("i", c.mappings.run_input, action.run_input)
       map("i", "<C-e>", action.edit)
+      -- Close the prompt with <C-e>
+      map("i", c.mappings.close, action.close)
 
       require("telescope.actions").close:enhance {
         post = function()

--- a/lua/telescope/_extensions/cmdline.lua
+++ b/lua/telescope/_extensions/cmdline.lua
@@ -59,7 +59,7 @@ local make_picker = function(opts)
       -- Run command from input field with <C-CR> (special cases) ??
       map("i", c.mappings.run_input, action.run_input)
       map("i", "<C-e>", action.edit)
-      -- Close the prompt with <C-e>
+      -- Close the prompt with <C-c>
       map("i", c.mappings.close, action.close)
 
       require("telescope.actions").close:enhance {


### PR DESCRIPTION
Adds a mappable close action with <C-c> as a default mapping.

The rationale is that the Vim Command Line can always be exited with <Esc>, while in Telescope, this only changes from Insert to Normal mode. This mappable action allows to optionally retain this behavior in telescope-cmdline, without changing  the default behavior.